### PR TITLE
Add sw_reset and reboot APIs aligned with AN5069

### DIFF
--- a/lis2mdl_reg.c
+++ b/lis2mdl_reg.c
@@ -769,94 +769,90 @@ int32_t lis2mdl_device_id_get(const stmdev_ctx_t *ctx, uint8_t *buff)
 }
 
 /**
-  * @brief  Software reset. Restore the default values in user registers.[set]
+  * @brief  Software reset. Restore the default values in user registers.
   *
   * @param  ctx   read / write interface definitions.(ptr)
-  * @param  val   change the values of soft_rst in reg CFG_REG_A
   * @retval       interface status.(MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2mdl_reset_set(const stmdev_ctx_t *ctx, uint8_t val)
+int32_t lis2mdl_sw_reset(const stmdev_ctx_t *ctx)
 {
-  lis2mdl_cfg_reg_a_t reg;
+  lis2mdl_cfg_reg_a_t reg = {0};
+  uint8_t retry = {0};
   int32_t ret;
 
-  ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_A, (uint8_t *)&reg, 1);
-
-  if (ret == 0)
+  if (ctx->mdelay == NULL)
   {
-    reg.soft_rst = val;
-    ret = lis2mdl_write_reg(ctx, LIS2MDL_CFG_REG_A, (uint8_t *)&reg, 1);
+    ret = -1;
+    goto exit;
   }
 
-  return ret;
-}
+  /* 1. Set the SOFT_RST bit of the CFG_REG_A register to 1. */
+  reg.soft_rst = 1;
+  ret = lis2mdl_write_reg(ctx, LIS2MDL_CFG_REG_A, (uint8_t *)&reg, 1);
 
-/**
-  * @brief  Software reset. Restore the default values in user registers.[get]
-  *
-  * @param  ctx   read / write interface definitions.(ptr)
-  * @param  val   change the values of soft_rst in reg CFG_REG_A.(ptr)
-  * @retval       interface status.(MANDATORY: return 0 -> no Error)
-  *
-  */
-int32_t lis2mdl_reset_get(const stmdev_ctx_t *ctx, uint8_t *val)
-{
-  lis2mdl_cfg_reg_a_t reg;
-  int32_t ret;
-
-  ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_A, (uint8_t *)&reg, 1);
-
-  if (ret != 0) { return ret; }
-
-  *val = reg.soft_rst;
-
-  return ret;
-}
-
-/**
-  * @brief  Reboot memory content. Reload the calibration parameters.[set]
-  *
-  * @param  ctx   read / write interface definitions.(ptr)
-  * @param  val   change the values of reboot in reg CFG_REG_A
-  * @retval       interface status.(MANDATORY: return 0 -> no Error)
-  *
-  */
-int32_t lis2mdl_boot_set(const stmdev_ctx_t *ctx, uint8_t val)
-{
-  lis2mdl_cfg_reg_a_t reg;
-  int32_t ret;
-
-  ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_A, (uint8_t *)&reg, 1);
-
-  if (ret == 0)
+  if (ret != 0)
   {
-    reg.reboot = val;
-    ret = lis2mdl_write_reg(ctx, LIS2MDL_CFG_REG_A, (uint8_t *)&reg, 1);
+    goto exit;
   }
 
+  /* 2. Poll the SOFT_RST bit of the CFG_REG_A register until it returns
+   * to 0. (should require 5us) */
+  do {
+    ret += lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_A, (uint8_t *)&reg, 1);
+
+    if (ret != 0)
+    {
+      goto exit;
+    }
+
+    ctx->mdelay(1);
+  } while (reg.soft_rst == 1 && retry++ < 3);
+
+  return (reg.soft_rst == 0) ? 0 : -1;
+
+exit:
   return ret;
 }
 
 /**
-  * @brief  Reboot memory content. Reload the calibration parameters.[get]
+  * @brief  Reboot memory content. Reload the calibration paramters.
+  * (20 ms boot procedure)
   *
   * @param  ctx   read / write interface definitions.(ptr)
-  * @param  val   change the values of reboot in reg CFG_REG_A.(ptr)
   * @retval       interface status.(MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2mdl_boot_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lis2mdl_reboot(const stmdev_ctx_t *ctx)
 {
   lis2mdl_cfg_reg_a_t reg;
   int32_t ret;
 
+  if (ctx->mdelay == NULL) {
+    ret = -1;
+    goto exit;
+  }
+
   ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_A, (uint8_t *)&reg, 1);
 
-  if (ret != 0) { return ret; }
+  if (ret != 0)
+  {
+    goto exit;
+  }
 
-  *val = reg.reboot;
+  /* 1. Set the REBOOT bit of the CFG_REG_A register to 1. */
+  reg.reboot = 1;
+  ret = lis2mdl_write_reg(ctx, LIS2MDL_CFG_REG_A, (uint8_t *)&reg, 1);
 
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  /* 2. Wait 20 ms for boot time */
+  ctx->mdelay(20);
+
+exit:
   return ret;
 }
 

--- a/lis2mdl_reg.h
+++ b/lis2mdl_reg.h
@@ -459,11 +459,9 @@ int32_t lis2mdl_temperature_raw_get(const stmdev_ctx_t *ctx,  int16_t *val);
 
 int32_t lis2mdl_device_id_get(const stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lis2mdl_reset_set(const stmdev_ctx_t *ctx, uint8_t val);
-int32_t lis2mdl_reset_get(const stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lis2mdl_sw_reset(const stmdev_ctx_t *ctx);
 
-int32_t lis2mdl_boot_set(const stmdev_ctx_t *ctx, uint8_t val);
-int32_t lis2mdl_boot_get(const stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lis2mdl_reboot(const stmdev_ctx_t *ctx);
 
 int32_t lis2mdl_self_test_set(const stmdev_ctx_t *ctx, uint8_t val);
 int32_t lis2mdl_self_test_get(const stmdev_ctx_t *ctx, uint8_t *val);


### PR DESCRIPTION
Enhance sw_reset and reboot APIs for compliance with AN5069 (version 4, Section 7)

- Updated sw_reset and reboot functions to fully comply with [AN5069](https://www.st.com/resource/en/application_note/an5069-lis2mdl-ultralowpower-highperformance-3axis-magnetometer-stmicroelectronics.pdf), incorporating the specified wait times required for software reset and reboot procedures.
- These APIs now replace the deprecated boot_set/get and reset_set/get functions, providing a more robust and standards-compliant implementation.