### PR TITLE
Restore reset_set/get boot_set/get APIs for consistency

### DIFF
--- a/lis2mdl_reg.c
+++ b/lis2mdl_reg.c
@@ -773,6 +773,102 @@ int32_t lis2mdl_device_id_get(const stmdev_ctx_t *ctx, uint8_t *buff)
 }
 
 /**
+  * @brief  Software reset. Restore the default values in user registers.[set]
+  *
+  * @param  ctx   read / write interface definitions.(ptr)
+  * @param  val   change the values of soft_rst in reg CFG_REG_A
+  * @retval       interface status.(MANDATORY: return 0 -> no Error)
+  *
+  */
+[[deprecated("Please use sw_reset to align with the AN")]]
+int32_t lis2mdl_reset_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lis2mdl_cfg_reg_a_t reg;
+  int32_t ret;
+
+  ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_A, (uint8_t *)&reg, 1);
+
+  if (ret == 0)
+  {
+    reg.soft_rst = val;
+    ret = lis2mdl_write_reg(ctx, LIS2MDL_CFG_REG_A, (uint8_t *)&reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values in user registers.[get]
+  *
+  * @param  ctx   read / write interface definitions.(ptr)
+  * @param  val   change the values of soft_rst in reg CFG_REG_A.(ptr)
+  * @retval       interface status.(MANDATORY: return 0 -> no Error)
+  *
+  */
+[[deprecated("Please use sw_reset to align with the AN")]]
+int32_t lis2mdl_reset_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lis2mdl_cfg_reg_a_t reg;
+  int32_t ret;
+
+  ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_A, (uint8_t *)&reg, 1);
+
+  if (ret != 0) { return ret; }
+
+  *val = reg.soft_rst;
+
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[set]
+  *
+  * @param  ctx   read / write interface definitions.(ptr)
+  * @param  val   change the values of reboot in reg CFG_REG_A
+  * @retval       interface status.(MANDATORY: return 0 -> no Error)
+  *
+  */
+[[deprecated("Please use reboot to align with the AN")]]
+int32_t lis2mdl_boot_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lis2mdl_cfg_reg_a_t reg;
+  int32_t ret;
+
+  ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_A, (uint8_t *)&reg, 1);
+
+  if (ret == 0)
+  {
+    reg.reboot = val;
+    ret = lis2mdl_write_reg(ctx, LIS2MDL_CFG_REG_A, (uint8_t *)&reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[get]
+  *
+  * @param  ctx   read / write interface definitions.(ptr)
+  * @param  val   change the values of reboot in reg CFG_REG_A.(ptr)
+  * @retval       interface status.(MANDATORY: return 0 -> no Error)
+  *
+  */
+[[deprecated("Please use reboot to align with the AN")]]
+int32_t lis2mdl_boot_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lis2mdl_cfg_reg_a_t reg;
+  int32_t ret;
+
+  ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_A, (uint8_t *)&reg, 1);
+
+  if (ret != 0) { return ret; }
+
+  *val = reg.reboot;
+
+  return ret;
+}
+
+/**
   * @brief  Software reset. Restore the default values in user registers.
   *
   * @param  ctx   read / write interface definitions.(ptr)

--- a/lis2mdl_reg.h
+++ b/lis2mdl_reg.h
@@ -459,6 +459,16 @@ int32_t lis2mdl_temperature_raw_get(const stmdev_ctx_t *ctx,  int16_t *val);
 
 int32_t lis2mdl_device_id_get(const stmdev_ctx_t *ctx, uint8_t *buff);
 
+// deprecated: Please use sw_reset to align with the AN
+int32_t lis2mdl_reset_set(const stmdev_ctx_t *ctx, uint8_t val);
+// deprecated: Please use sw_reset to align with the AN
+int32_t lis2mdl_reset_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+// deprecated: Please use reboot to align with the AN
+int32_t lis2mdl_boot_set(const stmdev_ctx_t *ctx, uint8_t val);
+// deprecated: Please use reboot to align with the AN
+int32_t lis2mdl_boot_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
 int32_t lis2mdl_sw_reset(const stmdev_ctx_t *ctx);
 
 int32_t lis2mdl_reboot(const stmdev_ctx_t *ctx);


### PR DESCRIPTION
Marked as deprecated to give users time to transition to the new APIs.

This fix addresses Issue #4.